### PR TITLE
fix(sha2crypt): salt encoded improperly

### DIFF
--- a/argon2_test.go
+++ b/argon2_test.go
@@ -30,8 +30,8 @@ func TestNewArgon2Hash(t *testing.T) {
 		{name: "ShouldHashPassword/argon2id/apple123", have: Argon2Hash{variant: Argon2VariantID, m: 65536, t: 4, p: 4}, password: "apple123", salt: "jfE+JyTE2DtnDCHknJOSsg", expected: "$argon2id$v=19$m=65536,t=4,p=4$jfE+JyTE2DtnDCHknJOSsg$+BPKo7PFUjKycwSpEK0Z1ciUPKp05uJvSfC7C+QAvAk"},
 		{name: "ShouldHashPassword/argon2id/another", have: Argon2Hash{variant: Argon2VariantID, m: 65536, t: 4, p: 4}, password: "another", salt: "FGJszRlDyDmntJbyHoNQag", expected: "$argon2id$v=19$m=65536,t=4,p=4$FGJszRlDyDmntJbyHoNQag$iGKvD7Oso+PcRhSVT/q/QCRb/mNZL0cwbtCKMzW/NPw"},
 		{name: "ShouldHashPassword/argon2id/th15isalongandcomplexpassw0rd@", have: Argon2Hash{variant: Argon2VariantID, m: 65536, t: 4, p: 4}, password: "th15isalongandcomplexpassw0rd@", salt: "qvU+J6Q0xnivdS5FSMm5Fw", expected: "$argon2id$v=19$m=65536,t=4,p=4$qvU+J6Q0xnivdS5FSMm5Fw$SpP3dXG6xTUcSxGrj+GTtWCFzekltzUodkIcPuX0KhY"},
-		{name: "ShouldHashPassword/argon2id/password123", have: Argon2Hash{variant: Argon2VariantID, m: 65536, t: 4, p: 4}, password: "password123", salt: "NcaYs3bufQ8BwPhfSyklBA", expected: "$argon2id$v=19$m=65536,t=4,p=4$rXUOwdg7x3iPkRKCMKZUSg$FgvrlMTstAr9BhVS2yYM/Of68HzCCJGqfgtQ2cGEY1w"},
-		{name: "ShouldHashPassword/argon2id/p@ssw0rd", have: Argon2Hash{variant: Argon2VariantID, m: 65536, t: 4, p: 4}, password: "p@ssw0rd", salt: "t7a2lhKCsBYC4HxPCcH4nw", expected: "$argon2i$v=19$m=65536,t=4,p=4$t7a2lhKCsBYC4HxPCcH4nw$zhSHktwftzV0aL6MgsN2eiZTa7gq8yFiHxJaomEeNfo"},
+		{name: "ShouldHashPassword/argon2id/password123", have: Argon2Hash{variant: Argon2VariantID, m: 65536, t: 4, p: 4}, password: "password123", salt: "NcaYs3bufQ8BwPhfSyklBA", expected: "$argon2id$v=19$m=65536,t=4,p=4$NcaYs3bufQ8BwPhfSyklBA$2rePx1Br3YqXPROcvo6Ze9fdMRAMLzvm2eFiX+j4Ct4"},
+		{name: "ShouldHashPassword/argon2id/p@ssw0rd", have: Argon2Hash{variant: Argon2VariantID, m: 65536, t: 4, p: 4}, password: "p@ssw0rd", salt: "t7a2lhKCsBYC4HxPCcH4nw", expected: "$argon2id$v=19$m=65536,t=4,p=4$t7a2lhKCsBYC4HxPCcH4nw$62nblX1UlyusrAsH8rrXYvq0z7wpWJVGC4+7Xooy8ss"},
 	}
 
 	for _, tc := range testCases {

--- a/sha2crypt.go
+++ b/sha2crypt.go
@@ -82,7 +82,7 @@ func (h *SHA2CryptHash) Hash(password string) (digest Digest, err error) {
 
 	var salt []byte
 
-	if salt, err = randomBytes(h.bytesSalt); err != nil {
+	if salt, err = randomCharacterBytes(h.bytesSalt, encodeTypeA); err != nil {
 		return nil, fmt.Errorf("sha2crypt hashing error: %w: %v", ErrSaltReadRandomBytes, err)
 	}
 

--- a/sha2crypt_digest.go
+++ b/sha2crypt_digest.go
@@ -79,24 +79,16 @@ func (d *SHA2CryptDigest) Decode(encodedDigest string) (err error) {
 		}
 	}
 
-	if d.salt, err = b64rs.DecodeString(salt); err != nil {
-		return fmt.Errorf("sha2crypt decode error: %w: %+v", ErrEncodedHashSaltEncoding, err)
-	}
-
-	d.key = []byte(key)
+	d.salt, d.key = []byte(salt), []byte(key)
 
 	return nil
 }
 
 // Encode this SHA2CryptDigest as a string for storage.
 func (d *SHA2CryptDigest) Encode() (hash string) {
-	salt := make([]byte, b64rs.EncodedLen(len(d.salt)))
-
-	b64rs.Encode(salt, d.salt)
-
 	return strings.ReplaceAll(fmt.Sprintf(StorageFormatSHACrypt,
 		d.variant.Prefix(), d.rounds,
-		salt, d.key,
+		d.salt, d.key,
 	), "\n", "")
 }
 

--- a/util.go
+++ b/util.go
@@ -52,6 +52,20 @@ func randomBytes(length int) (bytes []byte, err error) {
 	return bytes, nil
 }
 
+func randomCharacterBytes(n int, characters string) (bytes []byte, err error) {
+	bytes = make([]byte, n)
+
+	if _, err = rand.Read(bytes); err != nil {
+		return nil, err
+	}
+
+	for i, b := range bytes {
+		bytes[i] = characters[b%byte(len(characters))]
+	}
+
+	return bytes, nil
+}
+
 func roundDownToNearestMultiple(value, multiple int) int {
 	return (value / multiple) * multiple
 }


### PR DESCRIPTION
This fixes an issue where the salt was not encoded/decoded by the SHA2Crypt implementation correctly. It should be the bytes of a random string using the base64 alternate character set.