### PR TITLE
feat: plaintext key

### DIFF
--- a/algorithm/plaintext/digest.go
+++ b/algorithm/plaintext/digest.go
@@ -82,3 +82,9 @@ func (d *Digest) defaults() {
 		d.variant = VariantPlainText
 	}
 }
+
+// Key returns the raw plaintext key which can be used in situations where the plaintext value is required such as
+// validating JWT's signed by HMAC-SHA256.
+func (d *Digest) Key() []byte {
+	return d.key
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/go-crypt/crypt
 
 go 1.20
 
-require github.com/go-crypt/x v0.1.13
+require github.com/go-crypt/x v0.2.0
 
-require golang.org/x/sys v0.5.0 // indirect
+require golang.org/x/sys v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/go-crypt/x v0.1.13 h1:kQPfAfudCnpwSL6fS9d637v/QwEwnA6HEkE91yvzIC4=
-github.com/go-crypt/x v0.1.13/go.mod h1:vKR4KobuL9RFa+Rts0zItk+u77AFyrvZSD/xQZ4zCpw=
-golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
-golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/go-crypt/x v0.2.0 h1:rHMiKRAu6kFc+xAnQywDb3iHGpvrFbIGXnP3IfCZ+2U=
+github.com/go-crypt/x v0.2.0/go.mod h1:uLo5o+Cc8nvahDASQpntR1g3ZMUoq2LM/859PkhykC4=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Allows returning the plaintext key when you assert a digest to a *plaintext.Digest.