### PR TITLE
feat(shacrypt): allow omitted rounds

### DIFF
--- a/algorithm/shacrypt/const.go
+++ b/algorithm/shacrypt/const.go
@@ -4,6 +4,9 @@ const (
 	// EncodingFmt is the encoding format for this algorithm.
 	EncodingFmt = "$%s$rounds=%d$%s$%s"
 
+	// EncodingFmtRoundsOmitted is the encoding format for this algorithm when the rounds can be omitted.
+	EncodingFmtRoundsOmitted = "$%s$%s$%s"
+
 	// AlgName is the name for this algorithm.
 	AlgName = "shacrypt"
 
@@ -24,6 +27,9 @@ const (
 
 	// IterationsDefaultSHA512 is the default number of iterations for SHA512.
 	IterationsDefaultSHA512 = 500000
+
+	// IterationsDefaultOmitted is the default number of iterations when the rounds are omitted.
+	IterationsDefaultOmitted = 5000
 
 	// SaltLengthMin is the minimum salt length.
 	SaltLengthMin = 1

--- a/algorithm/shacrypt/digest.go
+++ b/algorithm/shacrypt/digest.go
@@ -50,10 +50,18 @@ func (d *Digest) MatchBytesAdvanced(passwordBytes []byte) (match bool, err error
 
 // Encode this Digest as a string for storage.
 func (d *Digest) Encode() (hash string) {
-	return strings.ReplaceAll(fmt.Sprintf(EncodingFmt,
-		d.variant.Prefix(), d.iterations,
-		d.salt, d.key,
-	), "\n", "")
+	switch d.iterations {
+	case IterationsDefaultOmitted:
+		return strings.ReplaceAll(fmt.Sprintf(EncodingFmtRoundsOmitted,
+			d.variant.Prefix(),
+			d.salt, d.key,
+		), "\n", "")
+	default:
+		return strings.ReplaceAll(fmt.Sprintf(EncodingFmt,
+			d.variant.Prefix(), d.iterations,
+			d.salt, d.key,
+		), "\n", "")
+	}
 }
 
 // String returns the storable format of the shacrypt.Digest hash utilizing fmt.Sprintf and shacrypt.EncodingFmt.


### PR DESCRIPTION
This allows rounds to be omitted when permitted by the spec. As per the spec it assumes the rounds are 5000 when omitted.

Closes #30