### PR TITLE
build(deps): update module github.com/go-crypt/x to v0.2.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,17 @@
 module github.com/go-crypt/crypt
 
-go 1.23
+go 1.22
 
 toolchain go1.23.1
 
 require (
-	github.com/go-crypt/x v0.2.20
+	github.com/go-crypt/x v0.2.21
 	github.com/stretchr/testify v1.9.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.24.0 // indirect
+	golang.org/x/sys v0.25.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,13 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-crypt/x v0.2.20 h1:FGVrC9sxtbeobxGBjyau7HeyXocSDftuP+LXNkbfcuY=
-github.com/go-crypt/x v0.2.20/go.mod h1:I1C6NXl8gmi9+V8p1Q+PknvDzdo3Yutlyvf51a0zbrA=
+github.com/go-crypt/x v0.2.21 h1:nLe8l5zGemmFpaBozaIdUmcvaedEbJHi19hf8hJH5B0=
+github.com/go-crypt/x v0.2.21/go.mod h1:7fYWzffOGWTnc6vG1NWaQgU0VQOyD7tryYxpQsFW6Do=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
-golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Downgraded the minimum required Go version from 1.23 to 1.22.
	- Updated the dependency `github.com/go-crypt/x` to version 0.2.21 for potential bug fixes or improvements.
	- Updated the indirect dependency `golang.org/x/sys` to version 0.25.0 for enhancements or fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->