### PR TITLE
build(deps): go 1.27

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,6 +44,7 @@ jobs:
         go:
           - '1.25'
           - '1.26'
+          - '1.27'
       fail-fast: false
     steps:
       - name: 'Harden Runner'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.graphifyignore
+graphify-out/
+
+# Added by ggshield
+.cache_ggshield

--- a/.renovaterc
+++ b/.renovaterc
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "constraints": {
-    "go": "1.26"
+    "go": "1.27"
   },
   "extends": [
     "config:recommended",

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Use `go get` to add this module to your project with `go get github.com/go-crypt
 
 ### Requirements
 
-- go 1.24+
+- go 1.25+
 
 ## Usage
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented minimum Go version to 1.25 or later.

* **Chores**
  * Added Go 1.27 to the build and test coverage.
  * Updated automated dependency maintenance to support Go 1.27.
  * Added generated output and cache files to ignore lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->