### PR TITLE
ci: remove go 1.25

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,6 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.25'
           - '1.26'
           - '1.27'
       fail-fast: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated build testing to cover Go versions 1.26 and 1.27.
  - Go 1.25 is no longer included in the build test matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->